### PR TITLE
add PYTHONPATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -90,7 +90,7 @@ set-env PATH '$HOME/.heroku/miniconda/bin:$PATH'
 set-env PYTHONUNBUFFERED true
 set-default-env LANG en_US.UTF-8
 set-default-env PYTHONHASHSEED random
-
+set-default-env PYTHONPATH /app/
 
 # Experimental post_compile hook.
 source $BIN_DIR/steps/hooks/post_compile


### PR DESCRIPTION
Similar to Python's buildpack, this needs PYTHONPATH for importing modules within the `/app/` level. 