### PR TITLE
Add django collect static support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,11 +73,13 @@ set -e
 # Make profile.d directory.
 mkdir -p $(dirname $PROFILE_PATH)
 
-# Actuall do the conda steps.
+# Actually do the conda steps.
 source $BIN_DIR/steps/conda_compile
 
+# Collect static
+sub-env $BIN_DIR/steps/collectstatic
+
 # ### Finalize
-#
 
 # Store new artifacts in cache.
 for dir in $CACHED_DIRS; do
@@ -90,7 +92,6 @@ set-env PATH '$HOME/.heroku/miniconda/bin:$PATH'
 set-env PYTHONUNBUFFERED true
 set-default-env LANG en_US.UTF-8
 set-default-env PYTHONHASHSEED random
-
 
 # Experimental post_compile hook.
 source $BIN_DIR/steps/hooks/post_compile

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+source $BIN_DIR/utils
+
+MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
+MANAGE_FILE=${MANAGE_FILE:-fakepath}
+
+[ -f .heroku/collectstatic_disabled ] && DISABLE_COLLECTSTATIC=1
+
+if [ ! "$DISABLE_COLLECTSTATIC" ] && [ -f "$MANAGE_FILE" ]; then
+    set +e
+
+    echo "-----> Preparing static assets"
+    # Check if collectstatic is configured properly.
+    python $MANAGE_FILE collectstatic --dry-run --noinput &> /dev/null && RUN_COLLECTSTATIC=true
+
+    # Compile assets if collectstatic appears to be kosher.
+    #if [ "$RUN_COLLECTSTATIC" ]; then
+
+    echo "       Running collectstatic..."
+    python $MANAGE_FILE collectstatic --noinput  2>&1 | sed '/^Copying/d;/^$/d;/^ /d' | indent
+
+    [ $? -ne 0 ] && {
+        echo " !     Error running 'manage.py collectstatic'. More info:"
+        echo "       http://devcenter.heroku.com/articles/django-assets"
+    }
+    #else
+    #    echo "       Collectstatic configuration error. To debug, run:"
+    #    echo "       $ heroku run python $MANAGE_FILE collectstatic --noinput"
+    #fi
+    echo
+fi

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -13,6 +13,12 @@ if [ -f conda-requirements.txt ]; then
     conda install --file conda-requirements.txt --yes | indent
 fi
 
+if [ -f conda-bokeh-dev-requirements.txt ]; then
+    puts-step "Installing bokeh-dev dependencies using Conda"
+    conda install -c bokeh/channel/dev --file conda-bokeh-dev-requirements.txt --yes | indent
+fi
+
+
 if [ -f requirements.txt ]; then
     puts-step "Installing dependencies using Pip"
     pip install -r requirements.txt  --exists-action=w --allow-all-external | indent

--- a/bin/utils
+++ b/bin/utils
@@ -52,3 +52,23 @@ function deep-mv (){
   rm -fr $1/!(tmp)
   find -H $1 -maxdepth 1 -name '.*' -a \( -type d -o -type f -o -type l \) -exec rm -fr '{}' \;
 }
+
+
+sub-env() {
+
+  WHITELIST=${2:-''}
+  BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH|PATH)$'}
+
+  (
+    if [ -d "$ENV_DIR" ]; then
+      for e in $(ls $ENV_DIR); do
+        echo "$e" | grep -E "$WHITELIST" | grep -qvE "$BLACKLIST" &&
+        export "$e=$(cat $ENV_DIR/$e)"
+        :
+      done
+    fi
+
+    $1
+
+  )
+}


### PR DESCRIPTION
* Take collect static pieces from main heroku python buildback
* Note - bpwatch not available on this buildpack
* Note, in your django settings.py you must have default values specified for
  variables pulled from env e.g. os.environ.get('SECRET KEY', 'my secret key') not os.environ['SECRET KEY']
  otherwise collect static will fail silently (this includes for database
  parameters).

Note this was done in a fairly uninformed way, copying and pasting the code from the most up to date heroku python buildpack which supports collect static (https://github.com/heroku/heroku-buildpack-python). But I thought it may be useful, for someone.