### PR TITLE
Recommending to purge_cache when large slug size

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,6 @@ OK
 
 ## Fair Warning
 
-Heroku limits the final application footprint (slug) size to 300MB. Start small. 
+Heroku limits the final application footprint (slug) size to 300MB. Start small. In case the slug size limit is exceeded, deleting the build cache through the [heroku-repo plugin](https://github.com/heroku/heroku-repo#purge_cache) might help.
 
 ॐ


### PR DESCRIPTION
Based on https://github.com/kennethreitz/conda-buildpack/issues/16. In this case, running `heroku repo:purge_cache` allowed to reduce the slug size below the 300MB limit. Thus, having such recommendation in the Readme might save some future headaches.