### PR TITLE
add environment vars to pre/post compile hook

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -16,6 +16,17 @@ BIN_DIR=$(cd $(dirname $0); pwd) # absolute path
 ROOT_DIR=$(dirname $BIN_DIR)
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
+
+
+if [ -d "$ENV_DIR" ]; then
+  for e in $(ls $ENV_DIR); do
+    echo "$e" | grep -E "$WHITELIST" | grep -qvE "$BLACKLIST" &&
+      export "$e=$(cat $ENV_DIR/$e)"
+      :
+  done
+fi
+
 
 CACHED_DIRS=".heroku"
 

--- a/bin/compile
+++ b/bin/compile
@@ -21,8 +21,6 @@ ENV_DIR=$3
 
 if [ -d "$ENV_DIR" ]; then
   echo "restoring environment"
-  WHITELIST=${2:-''}
-  BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH|PATH)$'}
   for e in $(ls $ENV_DIR); do
     export "$e=$(cat $ENV_DIR/$e)"
   done

--- a/bin/compile
+++ b/bin/compile
@@ -24,6 +24,7 @@ if [ -d "$ENV_DIR" ]; then
   WHITELIST=${2:-''}
   BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH|PATH)$'}
   for e in $(ls $ENV_DIR); do
+    echo "$e"
     echo "$e" | grep -E "$WHITELIST" | grep -qvE "$BLACKLIST" && 
     export "$e=$(cat $ENV_DIR/$e)"
     :

--- a/bin/compile
+++ b/bin/compile
@@ -24,12 +24,9 @@ if [ -d "$ENV_DIR" ]; then
   WHITELIST=${2:-''}
   BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH|PATH)$'}
   for e in $(ls $ENV_DIR); do
-    echo "$e"
     export "$e=$(cat $ENV_DIR/$e)"
   done
 fi
-
-echo "$FTP_USER"
 
 CACHED_DIRS=".heroku"
 

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ if [ -d "$ENV_DIR" ]; then
   BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH|PATH)$'}
   for e in $(ls $ENV_DIR); do
     echo "$e"
-    export "$e=$(cat $ENV_DIR/$e)
+    export "$e=$(cat $ENV_DIR/$e)"
   done
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -20,10 +20,13 @@ ENV_DIR=$3
 
 
 if [ -d "$ENV_DIR" ]; then
+  echo "restoring environment"
+  WHITELIST=${2:-''}
+  BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH|PATH)$'}
   for e in $(ls $ENV_DIR); do
-    echo "$e" | grep -E "$WHITELIST" | grep -qvE "$BLACKLIST" &&
-      export "$e=$(cat $ENV_DIR/$e)"
-      :
+    echo "$e" | grep -E "$WHITELIST" | grep -qvE "$BLACKLIST" && 
+    export "$e=$(cat $ENV_DIR/$e)"
+    :
   done
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -31,6 +31,7 @@ if [ -d "$ENV_DIR" ]; then
   done
 fi
 
+echo "$FTP_USER"
 
 CACHED_DIRS=".heroku"
 

--- a/bin/compile
+++ b/bin/compile
@@ -25,9 +25,7 @@ if [ -d "$ENV_DIR" ]; then
   BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH|PATH)$'}
   for e in $(ls $ENV_DIR); do
     echo "$e"
-    echo "$e" | grep -E "$WHITELIST" | grep -qvE "$BLACKLIST" && 
-    export "$e=$(cat $ENV_DIR/$e)"
-    :
+    export "$e=$(cat $ENV_DIR/$e)
   done
 fi
 


### PR DESCRIPTION
Those are visible in the default python buildpack, but are noticeably absent from the conda buildpack. 
They are useful for migrating the database.