### PR TITLE
Add ENV variables to customize buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -78,6 +78,7 @@ mkdir -p $(dirname $PROFILE_PATH)
 # Add environment variables
 export_env_dir $ENV_DIR
 
+
 # Actually do the conda steps.
 source $BIN_DIR/steps/conda_compile
 

--- a/bin/compile
+++ b/bin/compile
@@ -2,7 +2,7 @@
 
 # Usage:
 #
-#     $ bin/compile <build-dir> <cache-dir>
+#     $ bin/compile <build-dir> <cache-dir> <env-dir>
 
 
 # Fail fast and fail hard.
@@ -16,6 +16,7 @@ BIN_DIR=$(cd $(dirname $0); pwd) # absolute path
 ROOT_DIR=$(dirname $BIN_DIR)
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
 
 CACHED_DIRS=".heroku"
 
@@ -30,6 +31,7 @@ export BUILD_DIR CACHE_DIR BIN_DIR PROFILE_PATH
 
 # Syntax sugar.
 source $BIN_DIR/utils
+
 
 # Directory Hacks for path consistiency.
 APP_DIR='/app'
@@ -73,7 +75,10 @@ set -e
 # Make profile.d directory.
 mkdir -p $(dirname $PROFILE_PATH)
 
-# Actuall do the conda steps.
+# Add environment variables
+export_env_dir $ENV_DIR
+
+# Actually do the conda steps.
 source $BIN_DIR/steps/conda_compile
 
 # ### Finalize

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -11,6 +11,11 @@ echo "nomkl" > $HOME/.heroku/miniconda/conda-meta/pinned
 echo "added pinned file in $HOME/.heroku/miniconda/conda-meta/pinned"
 conda install nomkl
 
+if [ -n "${CONDA_CHANNELS}" ]; then
+    for channel in ${CONDA_CHANNELS}; do
+        conda config --add channels $channel
+    done
+fi
 
 if [ -f ${CONDA_REQ_FILE:-conda-requirements.txt} ]; then
     puts-step "Installing dependencies using Conda"

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -9,13 +9,15 @@ fi
 
 echo "nomkl" > $HOME/.heroku/miniconda/conda-meta/pinned
 echo "added pinned file in $HOME/.heroku/miniconda/conda-meta/pinned"
-conda install nomkl
 
 if [ -n "${CONDA_CHANNELS}" ]; then
     for channel in ${CONDA_CHANNELS}; do
+        puts-step "Add conda channel $channel"
         conda config --add channels $channel
     done
 fi
+
+conda install nomkl
 
 puts-step "Looking for conda deps in ${CONDA_REQ_FILE:-conda-requirements.txt}"
 if [ -f ${CONDA_REQ_FILE:-conda-requirements.txt} ]; then

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -12,14 +12,18 @@ echo "added pinned file in $HOME/.heroku/miniconda/conda-meta/pinned"
 conda install nomkl
 
 
-if [ -f conda-requirements.txt ]; then
+if [ -f ${CONDA_REQ_FILE:-conda-requirements.txt} ]; then
     puts-step "Installing dependencies using Conda"
-    conda install --file conda-requirements.txt --yes | indent
+    conda install --file ${CONDA_REQ_FILE:-conda-requirements.txt} --yes | indent
 fi
 
 if [ -f requirements.txt ]; then
     puts-step "Installing dependencies using Pip"
     pip install -r requirements.txt  --exists-action=w --allow-all-external | indent
+fi
+
+if [ -f setup.py ]; then
+    pip install --exists-action=w --allow-all-external -e . | indent
 fi
 
 # Clean up the installation environment .

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -17,17 +17,20 @@ if [ -n "${CONDA_CHANNELS}" ]; then
     done
 fi
 
+puts-step "Looking for conda deps in ${CONDA_REQ_FILE:-conda-requirements.txt}"
 if [ -f ${CONDA_REQ_FILE:-conda-requirements.txt} ]; then
-    puts-step "Installing dependencies using Conda"
+    puts-step "Installing dependencies using Conda form ${CONDA_REQ_FILE}"
     conda install --file ${CONDA_REQ_FILE:-conda-requirements.txt} --yes | indent
 fi
 
+puts-step "Looking for deps in requirements.txt"
 if [ -f requirements.txt ]; then
-    puts-step "Installing dependencies using Pip"
+    puts-step "Installing dependencies using Pip from requirements.txt"
     pip install -r requirements.txt  --exists-action=w --allow-all-external | indent
 fi
 
 if [ -f setup.py ]; then
+    puts-step "Installing setup.py using pip install -e ."
     pip install --exists-action=w --allow-all-external -e . | indent
 fi
 

--- a/bin/utils
+++ b/bin/utils
@@ -52,3 +52,16 @@ function deep-mv (){
   rm -fr $1/!(tmp)
   find -H $1 -maxdepth 1 -name '.*' -a \( -type d -o -type f -o -type l \) -exec rm -fr '{}' \;
 }
+
+export_env_dir() {
+  env_dir=$1
+  whitelist_regex=${2:-''}
+  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|JAVA_OPTS)$'}
+  if [ -d "$env_dir" ]; then
+    for e in $(ls $env_dir); do
+      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
+      export "$e=$(cat $env_dir/$e)"
+      :
+    done
+  fi
+}


### PR DESCRIPTION
Add several new environment variables to customize buildpack:

- Add environment variables from ENV_DIR
- Add `CONDA_REQ_FILE` to allow using other filename then `conda-requirements.txt`
- Add `CONDA_CHANNELS` add space separated channel names to use different conda channels
- Also install using `setup.py` if available instead of just `requirements.txt` and `conda-requirements.txt`. Use `pip install -e`.