### PR TITLE
Fix failing HTTP download

### DIFF
--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -1,6 +1,6 @@
 if [ ! -d /app/.heroku/miniconda ]; then
     puts-step "Preparing Python/Miniconda Environment"
-    curl -Os http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
+    curl -Os https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
     bash Miniconda-latest-Linux-x86_64.sh  -p /app/.heroku/miniconda/ -b | indent
     rm -fr Miniconda-latest-Linux-x86_64.sh
 


### PR DESCRIPTION
Seems like `repo.continuum.io` requires HTTPS now.