### PR TITLE
Custom Conda commands

### DIFF
--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -11,7 +11,7 @@ echo "nomkl" > $HOME/.heroku/miniconda/conda-meta/pinned
 echo "added pinned file in $HOME/.heroku/miniconda/conda-meta/pinned"
 conda install nomkl
 
-if [ -f conda-req.txt ]; then
+if [ -f conda-custom-install-commands.txt ]; then
     puts-step "Installing dependencies using Custom Conda commands"
     while IFS='' read -r line || [[ -n "$line" ]]; do
     	eval "$line --yes | indent"

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -15,7 +15,7 @@ if [ -f conda-custom-install-commands.txt ]; then
     puts-step "Installing dependencies using Custom Conda commands"
     while IFS='' read -r line || [[ -n "$line" ]]; do
     	eval "$line --yes | indent"
-	done < conda-req.txt
+	done < conda-custom-install-commands.txt
 fi
 
 if [ -f conda-requirements.txt ]; then

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -11,6 +11,12 @@ echo "nomkl" > $HOME/.heroku/miniconda/conda-meta/pinned
 echo "added pinned file in $HOME/.heroku/miniconda/conda-meta/pinned"
 conda install nomkl
 
+if [ -f conda-req.txt ]; then
+    puts-step "Installing dependencies using Custom Conda commands"
+    while IFS='' read -r line || [[ -n "$line" ]]; do
+    	eval "$line --yes | indent"
+	done < conda-req.txt
+fi
 
 if [ -f conda-requirements.txt ]; then
     puts-step "Installing dependencies using Conda"

--- a/test/conda-custom-install-commands.txt
+++ b/test/conda-custom-install-commands.txt
@@ -1,0 +1,1 @@
+conda install -c menpo opencv=2.4.11


### PR DESCRIPTION
With `conda-custom-install-commands.txt` we can use custom commands. So it is easy to install packages from custom channels.

For example with this install OpenCV:

`conda install -c menpo opencv=2.4.11`